### PR TITLE
feat: customize branding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -634,7 +634,7 @@ ALLOW_SHARED_LINKS_PUBLIC=true
 #                        UI                         #
 #===================================================#
 
-APP_TITLE=LibreChat
+APP_TITLE="SCL Agents Hub"
 # CUSTOM_FOOTER="My custom footer"
 HELP_AND_FAQ_URL=https://librechat.ai
 

--- a/client/src/components/Agents/Marketplace.tsx
+++ b/client/src/components/Agents/Marketplace.tsx
@@ -7,7 +7,7 @@ import { TooltipAnchor, Button, NewChatIcon, useMediaQuery } from '@librechat/cl
 import { PermissionTypes, Permissions, QueryKeys, Constants } from 'librechat-data-provider';
 import type t from 'librechat-data-provider';
 import type { ContextType } from '~/common';
-import { useGetEndpointsQuery, useGetAgentCategoriesQuery } from '~/data-provider';
+import { useGetEndpointsQuery, useGetAgentCategoriesQuery, useGetStartupConfig } from '~/data-provider';
 import { useDocumentTitle, useHasAccess, useLocalize } from '~/hooks';
 import MarketplaceAdminSettings from './MarketplaceAdminSettings';
 import { SidePanelProvider, useChatContext } from '~/Providers';
@@ -64,7 +64,10 @@ const AgentMarketplace: React.FC<AgentMarketplaceProps> = ({ className = '' }) =
   const [selectedAgent, setSelectedAgent] = useState<t.Agent | null>(null);
 
   // Set page title
-  useDocumentTitle(`${localize('com_agents_marketplace')} | LibreChat`);
+  const { data: startupConfig } = useGetStartupConfig();
+  useDocumentTitle(
+    `${localize('com_agents_marketplace')} | ${startupConfig?.appTitle ?? 'LibreChat'}`,
+  );
 
   // Ensure right sidebar is always visible in marketplace
   useEffect(() => {

--- a/client/src/components/Chat/Footer.tsx
+++ b/client/src/components/Chat/Footer.tsx
@@ -37,9 +37,7 @@ export default function Footer({ className }: { className?: string }) {
   const mainContentParts = (
     typeof config?.customFooter === 'string'
       ? config.customFooter
-      : '[LibreChat ' +
-        Constants.VERSION +
-        '](https://librechat.ai) - ' +
+      : `[${config?.appTitle ?? 'LibreChat'} ${Constants.VERSION}](https://librechat.ai) - ` +
         localize('com_ui_latest_footer')
   ).split('|');
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -52,8 +52,8 @@ export default defineConfig(({ command }) => ({
       },
       includeAssets: [],
       manifest: {
-        name: 'LibreChat',
-        short_name: 'LibreChat',
+        name: 'SCL Agents Hub',
+        short_name: 'SCL Agents Hub',
         start_url: '/',
         display: 'standalone',
         background_color: '#000000',


### PR DESCRIPTION
## Summary
- brand app as SCL Agents Hub
- load app title from config in marketplace and footer
- update PWA manifest and example env

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac94ad3a30832f9ec32e8265281ee0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dynamic app title across the Marketplace page and footer, using the configured application name with a fallback for consistency.
  - Updated PWA manifest to display the new application name in install prompts and app listings.

- Chores
  - Updated example environment configuration to reflect the new application title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->