### PR TITLE
feat: add red accent theme

### DIFF
--- a/client/src/components/Chat/Footer.tsx
+++ b/client/src/components/Chat/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer({ className }: { className?: string }) {
 
   const privacyPolicyRender = privacyPolicy?.externalUrl != null && (
     <a
-      className="text-text-secondary underline"
+        className="text-accent-red underline"
       href={privacyPolicy.externalUrl}
       target={privacyPolicy.openNewTab === true ? '_blank' : undefined}
       rel="noreferrer"
@@ -25,7 +25,7 @@ export default function Footer({ className }: { className?: string }) {
 
   const termsOfServiceRender = termsOfService?.externalUrl != null && (
     <a
-      className="text-text-secondary underline"
+        className="text-accent-red underline"
       href={termsOfService.externalUrl}
       target={termsOfService.openNewTab === true ? '_blank' : undefined}
       rel="noreferrer"
@@ -57,7 +57,7 @@ export default function Footer({ className }: { className?: string }) {
           a: ({ node: _n, href, children, ...otherProps }) => {
             return (
               <a
-                className="text-text-secondary underline"
+                  className="text-accent-red underline"
                 href={href}
                 target="_blank"
                 rel="noreferrer"

--- a/client/src/components/Chat/Input/SendButton.tsx
+++ b/client/src/components/Chat/Input/SendButton.tsx
@@ -23,7 +23,7 @@ const SubmitButton = React.memo(
             id="send-button"
             disabled={props.disabled}
             className={cn(
-              'rounded-full bg-text-primary p-1.5 text-text-primary outline-offset-4 transition-all duration-200 disabled:cursor-not-allowed disabled:text-text-secondary disabled:opacity-10',
+              'rounded-full bg-accent-red p-1.5 text-white outline-offset-4 transition-all duration-200 hover:bg-accent-red/90 disabled:cursor-not-allowed disabled:opacity-50',
             )}
             data-testid="send-button"
             type="submit"

--- a/client/src/components/Chat/Menus/HeaderNewChat.tsx
+++ b/client/src/components/Chat/Menus/HeaderNewChat.tsx
@@ -32,7 +32,7 @@ export default function HeaderNewChat() {
           variant="outline"
           data-testid="wide-header-new-chat-button"
           aria-label={localize('com_ui_new_chat')}
-          className="rounded-xl border border-border-light bg-surface-secondary p-2 hover:bg-surface-hover max-md:hidden"
+          className="rounded-xl border border-border-light bg-surface-secondary p-2 text-accent-red hover:bg-surface-hover hover:text-accent-red max-md:hidden"
           onClick={clickHandler}
         >
           <NewChatIcon />

--- a/client/src/components/Chat/Presentation.tsx
+++ b/client/src/components/Chat/Presentation.tsx
@@ -57,9 +57,9 @@ export default function Presentation({ children }: { children: React.ReactNode }
   }, []);
   const fullCollapse = useMemo(() => localStorage.getItem('fullPanelCollapse') === 'true', []);
 
-  return (
-    <DragDropWrapper className="relative flex w-full grow overflow-hidden bg-presentation">
-      <SidePanelProvider>
+    return (
+      <DragDropWrapper className="relative flex w-full grow overflow-hidden bg-splash">
+        <SidePanelProvider>
         <SidePanelGroup
           defaultLayout={defaultLayout}
           fullPanelCollapse={fullCollapse}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -40,6 +40,7 @@
   --red-800: #991b1b;
   --red-900: #7f1d1d;
   --red-950: #450a0a;
+  --accent-red: #ff0000;
   --amber-50: #fffbeb;
   --amber-100: #fef3c7;
   --amber-200: #fde68a;
@@ -91,6 +92,7 @@ html {
   --surface-destructive: var(--red-700);
   --surface-destructive-hover: var(--red-800);
   --surface-chat: var(--white);
+  --background-splash: linear-gradient(135deg, #ffffff 0%, #ffe5e5 40%, #ff0000 100%);
   --border-light: var(--gray-200);
   --border-medium-alt: var(--gray-300);
   --border-medium: var(--gray-300);
@@ -151,6 +153,8 @@ html {
   --surface-destructive: var(--red-800);
   --surface-destructive-hover: var(--red-900);
   --surface-chat: var(--gray-700);
+  --accent-red: #cc0000;
+  --background-splash: linear-gradient(135deg, #000000 0%, #440000 40%, #ff0000 100%);
   --border-light: var(--gray-700);
   --border-medium-alt: var(--gray-600);
   --border-medium: var(--gray-600);
@@ -205,6 +209,10 @@ html {
   --border-medium: rgba(217, 217, 227, 0.15);
   --border-heavy: rgba(217, 217, 227, 0.2);
   --border-xheavy: rgba(217, 217, 227, 0.25);
+}
+
+.bg-splash {
+  background: var(--background-splash);
 }
 
 .text-token-text-primary {

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -113,6 +113,7 @@ module.exports = {
         'surface-destructive': 'var(--surface-destructive)',
         'surface-destructive-hover': 'var(--surface-destructive-hover)',
         'surface-chat': 'var(--surface-chat)',
+        'accent-red': 'var(--accent-red)',
         'border-light': 'var(--border-light)',
         'border-medium': 'var(--border-medium)',
         'border-medium-alt': 'var(--border-medium-alt)',


### PR DESCRIPTION
## Summary
- add red accent color variable and gradient background for light/dark themes
- style chat presentation with new red splash background
- highlight key UI elements and links with red accents

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*

------
https://chatgpt.com/codex/tasks/task_e_68acdfb62b14832fa16694469e13d043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a splash background theme for presentation screens.
  - Added a new red accent color with light/dark variations for a refreshed look.

- Style
  - Send button updated to red with improved hover and disabled states.
  - Footer and Markdown links now display in red while preserving underlines.
  - “New Chat” header button text styled in red, including hover state.
  - Consistent theming applied for a cohesive appearance across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->