### PR TITLE
feat: improve accent-red styles

### DIFF
--- a/client/src/components/Chat/Input/SendButton.tsx
+++ b/client/src/components/Chat/Input/SendButton.tsx
@@ -23,7 +23,10 @@ const SubmitButton = React.memo(
             id="send-button"
             disabled={props.disabled}
             className={cn(
-              'rounded-full bg-accent-red p-1.5 text-white outline-offset-4 transition-all duration-200 hover:bg-accent-red/90 disabled:cursor-not-allowed disabled:opacity-50',
+              'rounded-full bg-accent-red p-1.5 text-white outline-offset-4 transition-all duration-200',
+              'hover:bg-accent-red/90 focus-visible:ring-2 focus-visible:ring-slate-400',
+              'focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900',
+              'disabled:cursor-not-allowed disabled:opacity-50'
             )}
             data-testid="send-button"
             type="submit"

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -40,7 +40,7 @@
   --red-800: #991b1b;
   --red-900: #7f1d1d;
   --red-950: #450a0a;
-  --accent-red: #ff0000;
+  --accent-red: 255 0 0;
   --amber-50: #fffbeb;
   --amber-100: #fef3c7;
   --amber-200: #fde68a;
@@ -153,7 +153,7 @@ html {
   --surface-destructive: var(--red-800);
   --surface-destructive-hover: var(--red-900);
   --surface-chat: var(--gray-700);
-  --accent-red: #cc0000;
+  --accent-red: 204 0 0;
   --background-splash: linear-gradient(135deg, #000000 0%, #440000 40%, #ff0000 100%);
   --border-light: var(--gray-700);
   --border-medium-alt: var(--gray-600);

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -1,5 +1,10 @@
 // const { fontFamily } = require('tailwindcss/defaultTheme');
 
+const withOpacityValue = (variable) => ({ opacityValue }) =>
+  opacityValue === undefined
+    ? `rgb(var(${variable}))`
+    : `rgb(var(${variable}) / ${opacityValue})`;
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -113,7 +118,7 @@ module.exports = {
         'surface-destructive': 'var(--surface-destructive)',
         'surface-destructive-hover': 'var(--surface-destructive-hover)',
         'surface-chat': 'var(--surface-chat)',
-        'accent-red': 'var(--accent-red)',
+        'accent-red': withOpacityValue('--accent-red'),
         'border-light': 'var(--border-light)',
         'border-medium': 'var(--border-medium)',
         'border-medium-alt': 'var(--border-medium-alt)',


### PR DESCRIPTION
## Summary
- add withOpacityValue helper for custom colors in Tailwind
- store accent red CSS variable as RGB values
- enhance SendButton accessibility with focus-visible ring

## Testing
- `npm run lint` *(fails: 344 problems)*
- `npm run test:client` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ace8eae3e0832f8286a7bc82144163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved send button focus and hover states for better accessibility, including visible focus rings and refined disabled behavior.
  * Updated accent color variables to RGB triplets to support opacity-based styling while preserving visual appearance.

* **Refactor**
  * Enhanced theming by introducing an opacity-aware color utility and adopting it for the accent color, enabling consistent use of opacity variants across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->