### PR TITLE
feat: improve accent-red styles

### DIFF
--- a/client/src/components/Chat/Input/SendButton.tsx
+++ b/client/src/components/Chat/Input/SendButton.tsx
@@ -23,7 +23,10 @@ const SubmitButton = React.memo(
             id="send-button"
             disabled={props.disabled}
             className={cn(
-              'rounded-full bg-accent-red p-1.5 text-white outline-offset-4 transition-all duration-200 hover:bg-accent-red/90 disabled:cursor-not-allowed disabled:opacity-50',
+              'rounded-full bg-accent-red p-1.5 text-white outline-offset-4 transition-all duration-200',
+              'hover:bg-accent-red/90 focus-visible:ring-2 focus-visible:ring-slate-400',
+              'focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900',
+              'disabled:cursor-not-allowed disabled:opacity-50'
             )}
             data-testid="send-button"
             type="submit"

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -40,7 +40,7 @@
   --red-800: #991b1b;
   --red-900: #7f1d1d;
   --red-950: #450a0a;
-  --accent-red: #ff0000;
+  --accent-red: 255 0 0;
   --amber-50: #fffbeb;
   --amber-100: #fef3c7;
   --amber-200: #fde68a;
@@ -153,7 +153,7 @@ html {
   --surface-destructive: var(--red-800);
   --surface-destructive-hover: var(--red-900);
   --surface-chat: var(--gray-700);
-  --accent-red: #cc0000;
+  --accent-red: 204 0 0;
   --background-splash: linear-gradient(135deg, #000000 0%, #440000 40%, #ff0000 100%);
   --border-light: var(--gray-700);
   --border-medium-alt: var(--gray-600);

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -1,4 +1,12 @@
 // const { fontFamily } = require('tailwindcss/defaultTheme');
+// Utility to apply opacity to CSS variable-based colors
+
+const withOpacityValue =
+  (variable) =>
+  ({ opacityValue }) =>
+    opacityValue === undefined
+      ? `rgb(var(${variable}))`
+      : `rgb(var(${variable}) / ${opacityValue})`;
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -113,7 +121,7 @@ module.exports = {
         'surface-destructive': 'var(--surface-destructive)',
         'surface-destructive-hover': 'var(--surface-destructive-hover)',
         'surface-chat': 'var(--surface-chat)',
-        'accent-red': 'var(--accent-red)',
+        'accent-red': withOpacityValue('--accent-red'),
         'border-light': 'var(--border-light)',
         'border-medium': 'var(--border-medium)',
         'border-medium-alt': 'var(--border-medium-alt)',


### PR DESCRIPTION
## Summary
- add withOpacityValue helper for accent-red Tailwind color
- store accent-red CSS variable in RGB for light and dark themes
- enhance Send button hover and focus styles

## Testing
- `npx eslint client/tailwind.config.cjs`
- `npm run test:client -- src/utils/latex.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ace8eae3e0832f8286a7bc82144163