### PR TITLE
feat: add accent red styling

### DIFF
--- a/client/src/components/Nav/NavToggle.tsx
+++ b/client/src/components/Nav/NavToggle.tsx
@@ -62,7 +62,7 @@ export default function NavToggle({
             <div className="flex h-6 w-6 flex-col items-center">
               {/* Top bar */}
               <div
-                className="h-3 w-1 rounded-full bg-black dark:bg-white"
+                className="h-3 w-1 rounded-full bg-accent-red"
                 style={{
                   ...transition,
                   transform: `translateY(0.15rem) rotate(${topBarRotation}) translateZ(0px)`,
@@ -70,7 +70,7 @@ export default function NavToggle({
               />
               {/* Bottom bar */}
               <div
-                className="h-3 w-1 rounded-full bg-black dark:bg-white"
+                className="h-3 w-1 rounded-full bg-accent-red"
                 style={{
                   ...transition,
                   transform: `translateY(-0.15rem) rotate(${bottomBarRotation}) translateZ(0px)`,

--- a/client/src/components/SidePanel/Nav.tsx
+++ b/client/src/components/SidePanel/Nav.tsx
@@ -37,6 +37,10 @@ function NavContent({ links, isCollapsed, resize }: Omit<NavProps, 'defaultActiv
                         <Button
                           variant="ghost"
                           size="icon"
+                          className={cn(
+                            'text-text-secondary hover:text-accent-red',
+                            link.id === active ? 'text-accent-red' : '',
+                          )}
                           onClick={(e) => {
                             if (link.onClick) {
                               link.onClick(e);
@@ -47,7 +51,7 @@ function NavContent({ links, isCollapsed, resize }: Omit<NavProps, 'defaultActiv
                             resize && resize(25);
                           }}
                         >
-                          <link.icon className="h-4 w-4 text-text-secondary" />
+                          <link.icon className="h-4 w-4" />
                           <span className="sr-only">{localize(link.title)}</span>
                         </Button>
                       }
@@ -66,7 +70,7 @@ function NavContent({ links, isCollapsed, resize }: Omit<NavProps, 'defaultActiv
                             <Button
                               variant="outline"
                               size="sm"
-                              className="w-full justify-start bg-transparent text-text-secondary data-[state=open]:bg-surface-secondary data-[state=open]:text-text-primary"
+                              className="w-full justify-start bg-transparent text-text-secondary hover:text-accent-red data-[state=open]:bg-surface-secondary data-[state=open]:text-accent-red"
                               onClick={(e) => {
                                 if (link.onClick) {
                                   link.onClick(e);
@@ -80,7 +84,7 @@ function NavContent({ links, isCollapsed, resize }: Omit<NavProps, 'defaultActiv
                                 <span
                                   className={cn(
                                     'ml-auto opacity-100 transition-all duration-300 ease-in-out',
-                                    variant === 'default' ? 'text-text-primary' : '',
+                                    variant === 'default' ? 'text-accent-red' : '',
                                   )}
                                 >
                                   {link.label}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -228,6 +228,14 @@ html {
   color: var(--text-tertiary);
 }
 
+a {
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: rgb(var(--accent-red));
+}
+
 .icon-xs {
   stroke-width: 1.5;
   height: 0.75rem;


### PR DESCRIPTION
## Summary
- add accent red hover and active styles to side navigation
- color nav toggle bars with theme-aware red
- add global link hover transition using accent red

## Testing
- `npm run lint` *(fails: Insert prettier errors, unused vars in data-schemas)*
- `npm run test:client` *(fails: missing modules librechat-data-provider, @librechat/client)*

------
https://chatgpt.com/codex/tasks/task_e_68acf28e2df8832f8a2811c606b11831