### PR TITLE
feat: add neon border theme

### DIFF
--- a/client/src/components/Agents/AgentCard.tsx
+++ b/client/src/components/Agents/AgentCard.tsx
@@ -18,13 +18,13 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onClick, className = '' })
 
   return (
     <div
-      className={cn(
-        'group relative h-40 overflow-hidden rounded-xl border border-border-light',
-        'cursor-pointer shadow-sm transition-all duration-200 hover:border-border-medium hover:shadow-lg',
-        'bg-surface-tertiary hover:bg-surface-hover',
-        'space-y-3 p-4',
-        className,
-      )}
+        className={cn(
+          'group relative h-40 overflow-hidden rounded-xl border border-border-neon neon-border',
+          'cursor-pointer shadow-sm transition-all duration-200 hover:border-border-neon hover:shadow-lg',
+          'bg-surface-tertiary hover:bg-surface-hover',
+          'space-y-3 p-4',
+          className,
+        )}
       onClick={onClick}
       aria-label={localize('com_agents_agent_card_label', {
         name: agent.name,
@@ -48,7 +48,7 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onClick, className = '' })
 
           {/* Category tag */}
           {agent.category && (
-            <div className="inline-flex items-center rounded-md border-border-xheavy bg-surface-active-alt px-2 py-1 text-xs font-medium">
+              <div className="inline-flex items-center rounded-md border border-border-neon neon-border bg-surface-active-alt px-2 py-1 text-xs font-medium">
               <Label className="line-clamp-1 font-normal">
                 {agent.category.charAt(0).toUpperCase() + agent.category.slice(1)}
               </Label>

--- a/client/src/components/Agents/Marketplace.tsx
+++ b/client/src/components/Agents/Marketplace.tsx
@@ -303,7 +303,7 @@ const AgentMarketplace: React.FC<AgentMarketplaceProps> = ({ className = '' }) =
                                 variant="outline"
                                 data-testid="agents-new-chat-button"
                                 aria-label={localize('com_ui_new_chat')}
-                                className="rounded-xl border border-border-light bg-surface-secondary p-2 hover:bg-surface-hover max-md:hidden"
+                                className="rounded-xl border border-border-neon neon-border bg-surface-secondary p-2 hover:bg-surface-hover max-md:hidden"
                                 onClick={handleNewChat}
                               >
                                 <NewChatIcon />

--- a/client/src/components/Agents/MarketplaceAdminSettings.tsx
+++ b/client/src/components/Agents/MarketplaceAdminSettings.tsx
@@ -147,12 +147,12 @@ const MarketplaceAdminSettings = () => {
       <OGDialogTrigger asChild>
         <Button
           variant="outline"
-          className="relative h-12 rounded-xl border-border-medium font-medium"
+          className="relative h-12 rounded-xl border border-border-neon neon-border font-medium"
         >
           <ShieldEllipsis className="cursor-pointer" aria-hidden="true" />
         </Button>
       </OGDialogTrigger>
-      <OGDialogContent className="w-11/12 max-w-md border-border-light bg-surface-primary text-text-primary">
+      <OGDialogContent className="w-11/12 max-w-md border border-border-neon neon-border bg-surface-primary text-text-primary">
         <OGDialogTitle>{`${localize('com_ui_admin_settings')} - ${localize(
           'com_ui_marketplace',
         )}`}</OGDialogTitle>
@@ -166,7 +166,7 @@ const MarketplaceAdminSettings = () => {
               isOpen={isRoleMenuOpen}
               setIsOpen={setIsRoleMenuOpen}
               trigger={
-                <Ariakit.MenuButton className="inline-flex w-1/4 items-center justify-center rounded-lg border border-border-light bg-transparent px-2 py-1 text-text-primary transition-all ease-in-out hover:bg-surface-tertiary">
+                <Ariakit.MenuButton className="inline-flex w-1/4 items-center justify-center rounded-lg border border-border-neon neon-border bg-transparent px-2 py-1 text-text-primary transition-all ease-in-out hover:bg-surface-tertiary">
                   {selectedRole}
                 </Ariakit.MenuButton>
               }

--- a/client/src/components/Agents/SearchBar.tsx
+++ b/client/src/components/Agents/SearchBar.tsx
@@ -67,13 +67,13 @@ const SearchBar: React.FC<SearchBarProps> = ({ value, onSearch, className = '' }
       <label htmlFor="agent-search" className="sr-only">
         {localize('com_agents_search_instructions')}
       </label>
-      <Input
-        id="agent-search"
-        type="text"
-        value={searchTerm}
-        onChange={handleChange}
-        placeholder={localize('com_agents_search_placeholder')}
-        className="h-12 rounded-xl border-border-medium bg-transparent pl-12 pr-12 text-lg text-text-primary shadow-md transition-[border-color,box-shadow] duration-200 placeholder:text-text-secondary focus:border-border-heavy focus:shadow-lg focus:ring-0"
+        <Input
+          id="agent-search"
+          type="text"
+          value={searchTerm}
+          onChange={handleChange}
+          placeholder={localize('com_agents_search_placeholder')}
+          className="h-12 rounded-xl border border-border-neon neon-border bg-transparent pl-12 pr-12 text-lg text-text-primary shadow-md transition-[border-color,box-shadow] duration-200 placeholder:text-text-secondary focus:border-border-neon focus:shadow-lg focus:ring-0"
         aria-label={localize('com_agents_search_aria')}
         aria-describedby="search-instructions search-results-count"
         autoComplete="off"

--- a/client/src/components/Auth/LoginForm.tsx
+++ b/client/src/components/Auth/LoginForm.tsx
@@ -67,8 +67,8 @@ const LoginForm: React.FC<TLoginFormProps> = ({ onSubmit, startupConfig, error, 
 
   return (
     <>
-      {showResendLink && (
-        <div className="mt-2 rounded-md border border-green-500 bg-green-500/10 px-3 py-2 text-sm text-gray-600 dark:text-gray-200">
+        {showResendLink && (
+          <div className="mt-2 rounded-md border border-border-neon neon-border bg-border-neon/10 px-3 py-2 text-sm text-gray-600 dark:text-gray-200">
           {localize('com_auth_email_verification_resend_prompt')}
           <button
             type="button"
@@ -102,7 +102,7 @@ const LoginForm: React.FC<TLoginFormProps> = ({ onSubmit, startupConfig, error, 
                 },
               })}
               aria-invalid={!!errors.email}
-              className="webkit-dark-styles transition-color peer w-full rounded-2xl border border-border-light bg-surface-primary px-3.5 pb-2.5 pt-3 text-text-primary duration-200 focus:border-green-500 focus:outline-none"
+                className="webkit-dark-styles transition-color peer w-full rounded-2xl border border-border-neon neon-border bg-surface-primary px-3.5 pb-2.5 pt-3 text-text-primary duration-200 focus:border-border-neon focus:outline-none"
               placeholder=" "
             />
             <label
@@ -129,7 +129,7 @@ const LoginForm: React.FC<TLoginFormProps> = ({ onSubmit, startupConfig, error, 
                 maxLength: { value: 128, message: localize('com_auth_password_max_length') },
               })}
               aria-invalid={!!errors.password}
-              className="webkit-dark-styles transition-color peer w-full rounded-2xl border border-border-light bg-surface-primary px-3.5 pb-2.5 pt-3 text-text-primary duration-200 focus:border-green-500 focus:outline-none"
+                className="webkit-dark-styles transition-color peer w-full rounded-2xl border border-border-neon neon-border bg-surface-primary px-3.5 pb-2.5 pt-3 text-text-primary duration-200 focus:border-border-neon focus:outline-none"
               placeholder=" "
             />
             <label

--- a/client/src/components/Messages/ContentRender.tsx
+++ b/client/src/components/Messages/ContentRender.tsx
@@ -110,7 +110,7 @@ const ContentRender = memo(
 
     const baseClasses = {
       common: 'group mx-auto flex flex-1 gap-3 transition-all duration-300 transform-gpu ',
-      card: 'relative w-full gap-1 rounded-lg border border-border-medium bg-surface-primary-alt p-2 md:w-1/2 md:gap-3 md:p-4',
+        card: 'relative w-full gap-1 rounded-lg border border-border-neon neon-border bg-surface-primary-alt p-2 md:w-1/2 md:gap-3 md:p-4',
       chat: maximizeChatSpace
         ? 'w-full max-w-full md:px-5 lg:px-1 xl:px-5'
         : 'md:max-w-[47rem] xl:max-w-[55rem]',
@@ -119,7 +119,7 @@ const ContentRender = memo(
     const conditionalClasses = {
       latestCard: isLatestCard ? 'bg-surface-secondary' : '',
       cardRender: showCardRender ? 'cursor-pointer transition-colors duration-300' : '',
-      focus: 'focus:outline-none focus:ring-2 focus:ring-border-xheavy',
+        focus: 'focus:outline-none focus:ring-2 focus:ring-border-neon',
     };
 
     return (

--- a/client/src/components/Nav/SearchBar.tsx
+++ b/client/src/components/Nav/SearchBar.tsx
@@ -101,10 +101,10 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
   return (
     <div
       ref={ref}
-      className={cn(
-        'group relative mt-1 flex h-10 cursor-pointer items-center gap-3 rounded-lg border-border-medium px-3 py-2 text-text-primary transition-colors duration-200 focus-within:bg-surface-hover hover:bg-surface-hover',
-        isSmallScreen === true ? 'mb-2 h-14 rounded-xl' : '',
-      )}
+        className={cn(
+          'group relative mt-1 flex h-10 cursor-pointer items-center gap-3 rounded-lg border border-border-neon neon-border px-3 py-2 text-text-primary transition-colors duration-200 focus-within:border-border-neon focus-within:bg-surface-hover hover:border-border-neon hover:bg-surface-hover',
+          isSmallScreen === true ? 'mb-2 h-14 rounded-xl' : '',
+        )}
     >
       <Search className="absolute left-3 h-4 w-4 text-text-secondary group-focus-within:text-text-primary group-hover:text-text-primary" />
       <input

--- a/client/src/components/Tools/AssistantToolsDialog.tsx
+++ b/client/src/components/Tools/AssistantToolsDialog.tsx
@@ -156,7 +156,7 @@ function AssistantToolsDialog({
           className="relative w-full transform overflow-hidden overflow-y-auto rounded-lg bg-surface-secondary text-left shadow-xl transition-all max-sm:h-full sm:mx-7 sm:my-8 sm:max-w-2xl lg:max-w-5xl xl:max-w-7xl"
           style={{ minHeight: '610px' }}
         >
-          <div className="flex items-center justify-between border-b-[1px] border-border-medium px-4 pb-4 pt-5 sm:p-6">
+          <div className="flex items-center justify-between border-b-[1px] border-border-neon px-4 pb-4 pt-5 sm:p-6">
             <div className="flex items-center">
               <div className="text-center sm:text-left">
                 <DialogTitle className="text-lg font-medium leading-6 text-text-primary">
@@ -211,7 +211,7 @@ function AssistantToolsDialog({
                   value={searchValue}
                   onChange={handleSearch}
                   placeholder={localize('com_nav_tool_search')}
-                  className="w-64 rounded border border-border-medium bg-transparent px-2 py-1 text-text-primary focus:outline-none"
+                  className="w-64 rounded border border-border-neon neon-border bg-transparent px-2 py-1 text-text-primary focus:outline-none"
                 />
               </div>
               <div

--- a/client/src/components/Tools/ToolItem.tsx
+++ b/client/src/components/Tools/ToolItem.tsx
@@ -28,7 +28,7 @@ function ToolItem({ tool, onAddTool, onRemoveTool, isInstalled = false }: ToolIt
   const icon = (tool as AgentToolType).metadata?.icon || (tool as TPlugin).icon;
 
   return (
-    <div className="flex flex-col gap-4 rounded border border-border-medium bg-transparent p-6">
+    <div className="flex flex-col gap-4 rounded border border-border-neon neon-border bg-transparent p-6">
       <div className="flex gap-4">
         <div className="h-[70px] w-[70px] shrink-0">
           <div className="relative h-full w-full">
@@ -39,7 +39,7 @@ function ToolItem({ tool, onAddTool, onRemoveTool, isInstalled = false }: ToolIt
                 className="h-full w-full rounded-[5px] bg-white"
               />
             ) : (
-              <div className="flex h-full w-full items-center justify-center rounded-[5px] border border-border-medium bg-transparent">
+              <div className="flex h-full w-full items-center justify-center rounded-[5px] border border-border-neon neon-border bg-transparent">
                 <Wrench className="h-8 w-8 text-text-secondary" />
               </div>
             )}

--- a/client/src/components/Tools/ToolSelectDialog.tsx
+++ b/client/src/components/Tools/ToolSelectDialog.tsx
@@ -197,7 +197,7 @@ function ToolSelectDialog({
           className="relative max-h-[90vh] w-full transform overflow-hidden overflow-y-auto rounded-lg bg-surface-secondary text-left shadow-xl transition-all max-sm:h-full sm:mx-7 sm:my-8 sm:max-w-2xl lg:max-w-5xl xl:max-w-7xl"
           style={{ minHeight: '610px' }}
         >
-          <div className="flex items-center justify-between border-b-[1px] border-border-medium px-4 pb-4 pt-5 sm:p-6">
+          <div className="flex items-center justify-between border-b-[1px] border-border-neon px-4 pb-4 pt-5 sm:p-6">
             <div className="flex items-center">
               <div className="text-center sm:text-left">
                 <DialogTitle className="text-lg font-medium leading-6 text-text-primary">
@@ -252,7 +252,7 @@ function ToolSelectDialog({
                   value={searchValue}
                   onChange={handleSearch}
                   placeholder={localize('com_nav_tool_search')}
-                  className="w-64 rounded border border-border-medium bg-transparent px-2 py-1 text-text-primary focus:outline-none"
+                  className="w-64 rounded border border-border-neon neon-border bg-transparent px-2 py-1 text-text-primary focus:outline-none"
                 />
               </div>
               <div

--- a/client/src/components/ui/TermsAndConditionsModal.tsx
+++ b/client/src/components/ui/TermsAndConditionsModal.tsx
@@ -87,16 +87,16 @@ const TermsAndConditionsModal = ({
         }
         buttons={
           <>
-            <button
-              onClick={handleDecline}
-              className="inline-flex h-10 items-center justify-center rounded-lg border border-border-heavy bg-surface-secondary px-4 py-2 text-sm text-text-primary hover:bg-surface-active"
-            >
+              <button
+                onClick={handleDecline}
+                className="inline-flex h-10 items-center justify-center rounded-lg border border-border-neon neon-border bg-surface-secondary px-4 py-2 text-sm text-text-primary hover:bg-surface-active"
+              >
               {localize('com_ui_decline')}
             </button>
-            <button
-              onClick={handleAccept}
-              className="inline-flex h-10 items-center justify-center rounded-lg border border-border-heavy bg-surface-secondary px-4 py-2 text-sm text-text-primary hover:bg-green-500 hover:text-white focus:bg-green-500 focus:text-white dark:hover:bg-green-600 dark:focus:bg-green-600"
-            >
+              <button
+                onClick={handleAccept}
+                className="inline-flex h-10 items-center justify-center rounded-lg border border-border-neon neon-border bg-surface-secondary px-4 py-2 text-sm text-text-primary hover:bg-green-500 hover:text-white focus:bg-green-500 focus:text-white dark:hover:bg-green-600 dark:focus:bg-green-600"
+              >
               {localize('com_ui_accept')}
             </button>
           </>

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -98,6 +98,7 @@ html {
   --border-medium: var(--gray-300);
   --border-heavy: var(--gray-400);
   --border-xheavy: var(--gray-500);
+  --border-neon: #ff0050;
   /* These are test styles */
 
   --background: 0 0% 100%;
@@ -160,6 +161,7 @@ html {
   --border-medium: var(--gray-600);
   --border-heavy: var(--gray-500);
   --border-xheavy: var(--gray-400);
+  --border-neon: #ff0050;
   /* These are test styles */
 
   --background: 0 0% 7%;
@@ -197,6 +199,7 @@ html {
   --border-medium: rgba(0, 0, 0, 0.15);
   --border-heavy: rgba(0, 0, 0, 0.2);
   --border-xheavy: rgba(0, 0, 0, 0.25);
+  --border-neon: #ff0050;
 }
 .gizmo.dark {
   --text-primary: var(--gray-100);
@@ -209,6 +212,7 @@ html {
   --border-medium: rgba(217, 217, 227, 0.15);
   --border-heavy: rgba(217, 217, 227, 0.2);
   --border-xheavy: rgba(217, 217, 227, 0.25);
+  --border-neon: #ff0050;
 }
 
 .bg-splash {
@@ -303,6 +307,16 @@ a:hover {
 .border-token-surface-tertiary {
   border-color: #ececf1;
   border-color: var(--surface-tertiary);
+}
+
+.neon-border {
+  border-color: var(--border-neon);
+  box-shadow: 0 0 5px var(--border-neon);
+}
+
+.dark .neon-border {
+  border-color: var(--border-neon);
+  box-shadow: 0 0 5px var(--border-neon);
 }
 
 .bg-token-surface-secondary {

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -124,6 +124,7 @@ module.exports = {
         'border-medium-alt': 'var(--border-medium-alt)',
         'border-heavy': 'var(--border-heavy)',
         'border-xheavy': 'var(--border-xheavy)',
+        'border-neon': withOpacityValue('--border-neon'),
         /* These are test styles */
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',

--- a/packages/client/src/theme/README.md
+++ b/packages/client/src/theme/README.md
@@ -154,6 +154,10 @@ function MyComponent() {
 - `border-border-medium` - Medium border
 - `border-border-heavy` - Heavy border
 - `border-border-xheavy` - Extra heavy border
+- `border-border-neon` - Neon red border
+
+### Utility Classes
+- `.neon-border` - Applies a neon red border with a subtle glow
 
 ### Other Colors
 - `bg-brand-purple` - Brand purple color

--- a/packages/client/src/theme/themes/dark.ts
+++ b/packages/client/src/theme/themes/dark.ts
@@ -45,6 +45,7 @@ export const darkTheme: IThemeRGB = {
   'rgb-border-medium-alt': '66 66 66', // #424242 (gray-600)
   'rgb-border-heavy': '89 89 89', // #595959 (gray-500)
   'rgb-border-xheavy': '153 150 150', // #999696 (gray-400)
+  'rgb-border-neon': '255 0 80', // neon red
 
   // Brand colors
   'rgb-brand-purple': '171 104 255', // #ab68ff

--- a/packages/client/src/theme/themes/default.ts
+++ b/packages/client/src/theme/themes/default.ts
@@ -45,6 +45,7 @@ export const defaultTheme: IThemeRGB = {
   'rgb-border-medium-alt': '205 205 205', // #cdcdcd (gray-300)
   'rgb-border-heavy': '153 150 150', // #999696 (gray-400)
   'rgb-border-xheavy': '89 89 89', // #595959 (gray-500)
+  'rgb-border-neon': '255 0 80', // neon red
 
   // Brand colors
   'rgb-brand-purple': '171 104 255', // #ab68ff

--- a/packages/client/src/theme/types/index.ts
+++ b/packages/client/src/theme/types/index.ts
@@ -43,6 +43,7 @@ export interface IThemeRGB {
   'rgb-border-medium-alt'?: string;
   'rgb-border-heavy'?: string;
   'rgb-border-xheavy'?: string;
+  'rgb-border-neon'?: string;
 
   // Brand colors
   'rgb-brand-purple'?: string;
@@ -104,6 +105,7 @@ export interface IThemeVariables {
   '--border-medium-alt': string;
   '--border-heavy': string;
   '--border-xheavy': string;
+  '--border-neon': string;
   '--brand-purple': string;
   '--presentation': string;
 
@@ -161,6 +163,7 @@ export interface IThemeColors {
   'border-medium-alt'?: string;
   'border-heavy'?: string;
   'border-xheavy'?: string;
+  'border-neon'?: string;
   'brand-purple'?: string;
   presentation?: string;
 

--- a/packages/client/src/theme/utils/applyTheme.ts
+++ b/packages/client/src/theme/utils/applyTheme.ts
@@ -57,6 +57,7 @@ function mapTheme(rgb: IThemeRGB): Partial<IThemeVariables> {
     'rgb-border-medium-alt': '--border-medium-alt',
     'rgb-border-heavy': '--border-heavy',
     'rgb-border-xheavy': '--border-xheavy',
+    'rgb-border-neon': '--border-neon',
     'rgb-brand-purple': '--brand-purple',
     'rgb-presentation': '--presentation',
 

--- a/packages/client/src/theme/utils/createTailwindColors.js
+++ b/packages/client/src/theme/utils/createTailwindColors.js
@@ -49,6 +49,7 @@ function createTailwindColors() {
     'border-medium-alt': withOpacity('--border-medium-alt'),
     'border-heavy': withOpacity('--border-heavy'),
     'border-xheavy': withOpacity('--border-xheavy'),
+    'border-neon': withOpacity('--border-neon'),
     'brand-purple': withOpacity('--brand-purple'),
     presentation: withOpacity('--presentation'),
     background: withOpacity('--background'),


### PR DESCRIPTION
## Summary
- add neon border color to theme configs and Tailwind
- introduce `.neon-border` utility with glow
- apply neon borders to agents, tools, auth, messages, nav components

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*
- `npm run build:client-package`


------
https://chatgpt.com/codex/tasks/task_e_68acf42eab94832fa087f58b2423d3b7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a neon border theme with a subtle glow, enhancing visibility on focus and hover across the app.
- Style
  - Applied neon border styling to agent cards, marketplace buttons, admin settings, search bars, login inputs/prompts, content cards, tools dialogs/items, and the terms modal, plus headers/dividers.
- Documentation
  - Documented the neon border token and .neon-border utility.
- Chores
  - Added neon border color tokens to the theme system and Tailwind configuration for consistent usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->