### PR TITLE
feat(ui): add neon glow utility and apply to chat and agent forms

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -238,12 +238,11 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
           <PromptsCommand index={index} textAreaRef={textAreaRef} submitPrompt={submitPrompt} />
           <div
             onClick={handleContainerClick}
+            data-scl-glow
             className={cn(
               'relative flex w-full flex-grow flex-col overflow-hidden rounded-t-3xl border pb-4 text-text-primary transition-all duration-200 sm:rounded-3xl sm:pb-0',
               isTextAreaFocused ? 'shadow-lg' : 'shadow-md',
-              isTemporary
-                ? 'border-violet-800/60 bg-violet-950/10'
-                : 'border-border-light bg-surface-chat',
+              isTemporary ? 'bg-violet-950/10' : 'bg-surface-chat',
             )}
           >
             <TextareaHeader addedConvo={addedConvo} setAddedConvo={setAddedConvo} />

--- a/client/src/components/Nav/SearchBar.tsx
+++ b/client/src/components/Nav/SearchBar.tsx
@@ -101,10 +101,11 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
   return (
     <div
       ref={ref}
-        className={cn(
-          'group relative mt-1 flex h-10 cursor-pointer items-center gap-3 rounded-lg border border-border-neon neon-border px-3 py-2 text-text-primary transition-colors duration-200 focus-within:border-border-neon focus-within:bg-surface-hover hover:border-border-neon hover:bg-surface-hover',
-          isSmallScreen === true ? 'mb-2 h-14 rounded-xl' : '',
-        )}
+      data-scl-glow
+      className={cn(
+        'group relative mt-1 flex h-10 cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 text-text-primary transition-colors duration-200 focus-within:bg-surface-hover hover:bg-surface-hover',
+        isSmallScreen === true ? 'mb-2 h-14 rounded-xl' : '',
+      )}
     >
       <Search className="absolute left-3 h-4 w-4 text-text-secondary group-focus-within:text-text-primary group-hover:text-text-primary" />
       <input

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -33,7 +33,7 @@ import { Panel } from '~/common';
 const labelClass = 'mb-2 text-token-text-primary block font-medium';
 const inputClass = cn(
   defaultTextProps,
-  'flex w-full px-3 py-2 border-border-light bg-surface-secondary focus-visible:ring-2 focus-visible:ring-ring-primary',
+  'flex w-full px-3 py-2 bg-surface-secondary focus-visible:ring-2 focus-visible:ring-ring-primary',
   removeFocusOutlines,
 );
 
@@ -211,6 +211,7 @@ export default function AgentConfig({ createMutation }: Pick<AgentPanelProps, 'c
                   {...field}
                   value={field.value ?? ''}
                   maxLength={256}
+                  data-scl-glow
                   className={inputClass}
                   id="name"
                   type="text"
@@ -251,6 +252,7 @@ export default function AgentConfig({ createMutation }: Pick<AgentPanelProps, 'c
                 {...field}
                 value={field.value ?? ''}
                 maxLength={512}
+                data-scl-glow
                 className={inputClass}
                 id="description"
                 type="text"

--- a/client/src/components/SidePanel/Agents/Instructions.tsx
+++ b/client/src/components/SidePanel/Agents/Instructions.tsx
@@ -11,7 +11,7 @@ import { useLocalize } from '~/hooks';
 
 const inputClass = cn(
   defaultTextProps,
-  'flex w-full px-3 py-2 border-border-light bg-surface-secondary focus-visible:ring-2 focus-visible:ring-ring-primary',
+  'flex w-full px-3 py-2 bg-surface-secondary focus-visible:ring-2 focus-visible:ring-ring-primary',
   removeFocusOutlines,
 );
 
@@ -82,6 +82,7 @@ export default function Instructions() {
             <textarea
               {...field}
               value={field.value ?? ''}
+              data-scl-glow
               className={cn(inputClass, 'min-h-[100px] resize-y')}
               id="instructions"
               placeholder={localize('com_agents_instructions_placeholder')}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -99,6 +99,10 @@ html {
   --border-heavy: var(--gray-400);
   --border-xheavy: var(--gray-500);
   --border-neon: #ff0050;
+  /* === SCL Accent Tokens (FF0000) === */
+  --scl-accent: 255, 0, 0;
+  --scl-glow: 0 0 .25rem rgba(var(--scl-accent), .28),
+              0 0 .6rem rgba(var(--scl-accent), .18);
   /* These are test styles */
 
   --background: 0 0% 100%;
@@ -187,6 +191,30 @@ html {
   --chart-4: 280 65% 60%;
   --chart-5: 340 75% 55%;
   --switch-unchecked: 0 0% 40%;
+  --scl-glow: 0 0 .6rem rgba(var(--scl-accent), .45),
+              0 0 1.2rem rgba(var(--scl-accent), .30);
+}
+
+/* Neon utility – drop-in on any input/textarea wrapper or the element itself */
+[data-scl-glow],
+.scl-neon {
+  --ring: 0 100% 50%;
+  --tw-ring-color: hsl(var(--ring));
+
+  border-color: rgba(var(--scl-accent), .50) !important;
+  box-shadow:
+    0 0 0 1px rgba(var(--scl-accent), .45) inset,
+    var(--scl-glow);
+}
+
+[data-scl-glow]:focus,
+[data-scl-glow]:focus-within,
+.scl-neon:focus,
+.scl-neon:focus-within {
+  box-shadow:
+    0 0 0 1px rgba(var(--scl-accent), .65) inset,
+    var(--scl-glow),
+    0 0 0 3px rgba(var(--scl-accent), .15);
 }
 .gizmo {
   --text-primary: var(--gizmo-gray-950);


### PR DESCRIPTION
## Summary
- add theme-aware neon glow utility via `data-scl-glow`
- apply glow to sidebar search, chat compose box, and agent builder fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adecf97180832f986c50e0fad097d3