### PR TITLE
Redirect login to Agent Marketplace

### DIFF
--- a/client/src/components/Auth/Registration.tsx
+++ b/client/src/components/Auth/Registration.tsx
@@ -47,7 +47,7 @@ const Registration: React.FC = () => {
         setCountdown((prevCountdown) => {
           if (prevCountdown <= 1) {
             clearInterval(timer);
-            navigate('/c/new', { replace: true });
+            navigate('/agents', { replace: true });
             return 0;
           } else {
             return prevCountdown - 1;

--- a/client/src/components/Auth/VerifyEmail.tsx
+++ b/client/src/components/Auth/VerifyEmail.tsx
@@ -22,7 +22,7 @@ function RequestPasswordReset() {
       setCountdown((prevCountdown) => {
         if (prevCountdown <= 1) {
           clearInterval(timer);
-          navigate('/c/new', { replace: true });
+          navigate('/agents', { replace: true });
           return 0;
         }
         return prevCountdown - 1;

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -86,7 +86,7 @@ const AuthContextProvider = ({
         return;
       }
       setError(undefined);
-      setUserContext({ token, isAuthenticated: true, user, redirect: '/c/new' });
+      setUserContext({ token, isAuthenticated: true, user, redirect: '/agents' });
     },
     onError: (error: TResError | unknown) => {
       const resError = error as TResError;

--- a/client/src/routes/Layouts/Startup.tsx
+++ b/client/src/routes/Layouts/Startup.tsx
@@ -30,7 +30,7 @@ export default function StartupLayout({ isAuthenticated }: { isAuthenticated?: b
 
   useEffect(() => {
     if (isAuthenticated) {
-      navigate('/c/new', { replace: true });
+      navigate('/agents', { replace: true });
     }
     if (data) {
       setStartupConfig(data);

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -96,7 +96,7 @@ export const router = createBrowserRouter([
         children: [
           {
             index: true,
-            element: <Navigate to="/c/new" replace={true} />,
+            element: <Navigate to="/agents" replace={true} />,
           },
           {
             path: 'c/:conversationId?',


### PR DESCRIPTION
## Summary
- Default post-login page to Agent Marketplace
- Redirect verification and registration flows to Agent Marketplace
- Replace chat index route with Agent Marketplace

## Testing
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*
- `npm run lint` *(no output; command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ae300f659c832f9320c7668593cc96