### PR TITLE
Default sidebars closed on login

### DIFF
--- a/client/src/components/Chat/Presentation.tsx
+++ b/client/src/components/Chat/Presentation.tsx
@@ -51,11 +51,13 @@ export default function Presentation({ children }: { children: React.ReactNode }
     const resizableLayout = localStorage.getItem('react-resizable-panels:layout');
     return typeof resizableLayout === 'string' ? JSON.parse(resizableLayout) : undefined;
   }, []);
-  const defaultCollapsed = useMemo(() => {
-    const collapsedPanels = localStorage.getItem('react-resizable-panels:collapsed');
-    return typeof collapsedPanels === 'string' ? JSON.parse(collapsedPanels) : true;
+  const defaultCollapsed = true;
+  const fullCollapse = true;
+
+  useEffect(() => {
+    localStorage.setItem('react-resizable-panels:collapsed', 'true');
+    localStorage.setItem('fullPanelCollapse', 'true');
   }, []);
-  const fullCollapse = useMemo(() => localStorage.getItem('fullPanelCollapse') === 'true', []);
 
   return (
     <DragDropWrapper className="relative flex w-full grow overflow-hidden bg-presentation">

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -24,10 +24,11 @@ import { Banner } from '~/components/Banners';
 export default function Root() {
   const [showTerms, setShowTerms] = useState(false);
   const [bannerHeight, setBannerHeight] = useState(0);
-  const [navVisible, setNavVisible] = useState(() => {
-    const savedNavVisible = localStorage.getItem('navVisible');
-    return savedNavVisible !== null ? JSON.parse(savedNavVisible) : true;
-  });
+  const [navVisible, setNavVisible] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem('navVisible', JSON.stringify(false));
+  }, []);
 
   const { isAuthenticated, logout } = useAuthContext();
 


### PR DESCRIPTION
## Summary
- Ensure navigation sidebar starts closed for each session
- Collapse the side panel by default and reset related localStorage

## Testing
- `npm run test:client` (fails: Cannot find module 'librechat-data-provider')
- `npm run test:api` (fails: Cannot find module '@librechat/api')

------
https://chatgpt.com/codex/tasks/task_e_68ae307fc354832fb8d66784ef186146