### PR TITLE
Collapse nav and builder sidebars by default

### DIFF
--- a/client/src/components/Agents/Marketplace.tsx
+++ b/client/src/components/Agents/Marketplace.tsx
@@ -42,7 +42,7 @@ const AgentMarketplace: React.FC<AgentMarketplaceProps> = ({ className = '' }) =
 
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
   const { navVisible, setNavVisible } = useOutletContext<ContextType>();
-  const [hideSidePanel, setHideSidePanel] = useRecoilState(store.hideSidePanel);
+  const [, setHideSidePanel] = useRecoilState(store.hideSidePanel);
 
   // Get URL parameters
   const searchQuery = searchParams.get('q') || '';
@@ -66,14 +66,16 @@ const AgentMarketplace: React.FC<AgentMarketplaceProps> = ({ className = '' }) =
   // Set page title
   useDocumentTitle(`${localize('com_agents_marketplace')} | LibreChat`);
 
-  // Ensure right sidebar is always visible in marketplace
+  // Ensure navigation and builder sidebars start collapsed in marketplace
   useEffect(() => {
     setHideSidePanel(false);
+    setNavVisible(false);
 
-    // Also try to force expand via localStorage
     localStorage.setItem('hideSidePanel', 'false');
-    localStorage.setItem('fullPanelCollapse', 'false');
-  }, [setHideSidePanel, hideSidePanel]);
+    localStorage.setItem('fullPanelCollapse', 'true');
+    localStorage.setItem('react-resizable-panels:collapsed', 'true');
+    localStorage.setItem('navVisible', JSON.stringify(false));
+  }, [setHideSidePanel, setNavVisible]);
 
   // Ensure endpoints config is loaded first (required for agent queries)
   useGetEndpointsQuery();

--- a/client/src/components/Chat/Presentation.tsx
+++ b/client/src/components/Chat/Presentation.tsx
@@ -51,12 +51,22 @@ export default function Presentation({ children }: { children: React.ReactNode }
     const resizableLayout = localStorage.getItem('react-resizable-panels:layout');
     return typeof resizableLayout === 'string' ? JSON.parse(resizableLayout) : undefined;
   }, []);
-  const defaultCollapsed = true;
-  const fullCollapse = true;
+  const defaultCollapsed = useMemo(
+    () => localStorage.getItem('react-resizable-panels:collapsed') === 'true',
+    [],
+  );
+  const fullCollapse = useMemo(
+    () => localStorage.getItem('fullPanelCollapse') === 'true',
+    [],
+  );
 
   useEffect(() => {
-    localStorage.setItem('react-resizable-panels:collapsed', 'true');
-    localStorage.setItem('fullPanelCollapse', 'true');
+    if (localStorage.getItem('react-resizable-panels:collapsed') === null) {
+      localStorage.setItem('react-resizable-panels:collapsed', 'true');
+    }
+    if (localStorage.getItem('fullPanelCollapse') === null) {
+      localStorage.setItem('fullPanelCollapse', 'true');
+    }
   }, []);
 
   return (

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 import type { ContextType } from '~/common';
 import {
   useSearchEnabled,
@@ -20,15 +21,21 @@ import { TermsAndConditionsModal } from '~/components/ui';
 import { Nav, MobileNav } from '~/components/Nav';
 import { useHealthCheck } from '~/data-provider';
 import { Banner } from '~/components/Banners';
+import store from '~/store';
 
 export default function Root() {
   const [showTerms, setShowTerms] = useState(false);
   const [bannerHeight, setBannerHeight] = useState(0);
   const [navVisible, setNavVisible] = useState(false);
+  const setHideSidePanel = useSetRecoilState(store.hideSidePanel);
 
   useEffect(() => {
     localStorage.setItem('navVisible', JSON.stringify(false));
-  }, []);
+    localStorage.setItem('react-resizable-panels:collapsed', 'true');
+    localStorage.setItem('fullPanelCollapse', 'true');
+    localStorage.setItem('hideSidePanel', 'false');
+    setHideSidePanel(false);
+  }, [setHideSidePanel]);
 
   const { isAuthenticated, logout } = useAuthContext();
 


### PR DESCRIPTION
## Summary
- Force nav and builder side panels to start closed each session
- Load chat presentation collapse state from `localStorage`
- Ensure agent marketplace opens with nav and builder sidebars collapsed

## Testing
- `npm run lint`
- `npm run test:client` *(fails: Cannot find module 'librechat-data-provider')*


------
https://chatgpt.com/codex/tasks/task_e_68ae384ec4ec832f86d91061ea96e326